### PR TITLE
Fix GetTensorShape() TF_GraphGetTensorShape should not use ref for []

### DIFF
--- a/TensorFlowSharp/Tensorflow.cs
+++ b/TensorFlowSharp/Tensorflow.cs
@@ -447,7 +447,7 @@ namespace TensorFlow
 
 		// extern void TF_GraphGetTensorShape (TF_Graph *graph, TF_Output output, int64_t *dims, int num_dims, TF_Status *status);
 		[DllImport (NativeBinding.TensorFlowLibrary)]
-		static extern unsafe void TF_GraphGetTensorShape (TF_Graph graph, TFOutput output, ref long [] dims, int num_dims, TF_Status status);
+		static extern unsafe void TF_GraphGetTensorShape (TF_Graph graph, TFOutput output, long [] dims, int num_dims, TF_Status status);
 
 		public long [] GetTensorShape (TFOutput output, TFStatus status = null)
 		{
@@ -459,7 +459,7 @@ namespace TensorFlow
 				return null;
 			
 			var dims = new long [n];
-			TF_GraphGetTensorShape (handle, output, ref dims, dims.Length, cstatus.handle);
+			TF_GraphGetTensorShape (handle, output, dims, dims.Length, cstatus.handle);
 			cstatus.CheckMaybeRaise (status);
 			return dims;
 		}
@@ -632,7 +632,7 @@ namespace TensorFlow
 			if (ndims == 0)
 				return null;
 			var ret = new long [ndims];
-			TF_GraphGetTensorShape (handle, output, ref ret, ndims, cstatus.handle);
+			TF_GraphGetTensorShape (handle, output, ret, ndims, cstatus.handle);
 			cstatus.CheckMaybeRaise (status);
 			return ret;
 		}


### PR DESCRIPTION
Hey Miguel, please check if this fix is looks right. If this is correct I expect there are other places where the ref [] pattern needs to be fixed (I just did the one causing SampleTest to fail). btw I also wondered if these pointers should be handled as unsafe but the post below says no...

UPDATE  I just noticed that the unsafe declaration is in the DllImport (static extern unsafe void TF_GraphGetTensorShape...) so yeah, I think this is the correct fix. Certainly the old code which passed a ref to the array won't work as the C code would have to allocate and return a C# managed object. Also this works :)

This fixes a memory violation running SampleTest, for extern C arrays are passed directly, not via ref which requires C to create a managed object.
http://stackoverflow.com/questions/741206/using-arrays-and-pointers-in-c-sharp-with-c-dll