### PR TITLE
Ensure memory-release delegates are not garbage-collected (which appa…

### DIFF
--- a/TensorFlowSharp/Buffer.cs
+++ b/TensorFlowSharp/Buffer.cs
@@ -124,14 +124,15 @@ namespace TensorFlow
 			Marshal.FreeHGlobal (data);
 		}
 
-		static IntPtr FreeBufferFunc;
+        static IntPtr FreeBufferFunc;
+        static BufferReleaseFunc FreeBlockDelegate;
 
         static TFBuffer()
         {
-            BufferReleaseFunc del = (data, length) => FreeBlock(data, length);
-            GCHandle.Alloc(del);
-            FreeBufferFunc = Marshal.GetFunctionPointerForDelegate(del);
+            FreeBlockDelegate = FreeBlock;
+            FreeBufferFunc = Marshal.GetFunctionPointerForDelegate<BufferReleaseFunc>(FreeBlockDelegate);
         }
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:TensorFlow.TFBuffer"/> by making a copy of the provided byte array.

--- a/TensorFlowSharp/Buffer.cs
+++ b/TensorFlowSharp/Buffer.cs
@@ -125,24 +125,23 @@ namespace TensorFlow
 		}
 
 		static IntPtr FreeBufferFunc;
-		static BufferReleaseFunc FreeBlockDelegate;
-		
-		static TFBuffer ()
-		{
-			FreeBlockDelegate = FreeBlock;
-			FreeBufferFunc = Marshal.GetFunctionPointerForDelegate<BufferReleaseFunc> (FreeBlockDelegate);
-		}
 
+        static TFBuffer()
+        {
+            BufferReleaseFunc del = (data, length) => FreeBlock(data, length);
+            GCHandle.Alloc(del);
+            FreeBufferFunc = Marshal.GetFunctionPointerForDelegate(del);
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="T:TensorFlow.TFBuffer"/> by making a copy of the provided byte array.
-		/// </summary>
-		/// <param name="buffer">Buffer of data that will be wrapped.</param>
-		/// <remarks>
-		/// This constructor makes a copy of the data into an unmanaged buffer, 
-		/// so the byte array is not pinned.
-		/// </remarks>
-		public TFBuffer (byte [] buffer) : this (buffer, 0, buffer.Length) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:TensorFlow.TFBuffer"/> by making a copy of the provided byte array.
+        /// </summary>
+        /// <param name="buffer">Buffer of data that will be wrapped.</param>
+        /// <remarks>
+        /// This constructor makes a copy of the data into an unmanaged buffer, 
+        /// so the byte array is not pinned.
+        /// </remarks>
+        public TFBuffer (byte [] buffer) : this (buffer, 0, buffer.Length) { }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="T:TensorFlow.TFBuffer"/> by making a copy of the provided byte array.

--- a/TensorFlowSharp/Tensor.cs
+++ b/TensorFlowSharp/Tensor.cs
@@ -61,15 +61,8 @@ namespace TensorFlow
 			gch.Free ();
 		}
 
-        static Deallocator FreeTensorHandleDelegate;
-        static Deallocator FreeTensorDataDelegate;
-        static TFTensor()
-        {
-            FreeTensorHandleDelegate = (data, size, deallocatorData) => FreeTensorHandle(data, size, deallocatorData);
-            GCHandle.Alloc(FreeTensorHandleDelegate);
-            FreeTensorDataDelegate = (data, len, closure) => FreeTensorData(data, len, closure);
-            GCHandle.Alloc(FreeTensorDataDelegate);
-        }
+        static Deallocator FreeTensorHandleDelegate = (data, size, deallocatorData) => FreeTensorHandle(data, size, deallocatorData);
+        static Deallocator FreeTensorDataDelegate = (data, len, closure) => FreeTensorData(data, len, closure);
 
         // TODO: Other overloads we could add: String, Complex (float), Bool, QInt8, QUInt8, QInt32, Bfloat16,
         // QInt16, QUint16, Half, Resource


### PR DESCRIPTION
…rently only happens in Microsoft Windows VM) by using GCHandle.Alloc() on them.

Without doing this, I quickly get errors indicating delegates have been garbage-collected whenever I dispose of TFBuffer or TFTensor objects.