### PR TITLE
Editorconfig to keep the original code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*.cs]
+indent_style = tab
+indent_size = 4
+csharp_space_before_open_square_brackets = true
+csharp_space_between_method_call_name_and_opening_parenthesis = true
+csharp_space_between_method_declaration_name_and_open_parenthesis = true
+csharp_new_line_before_else = false
+csharp_new_line_before_open_brace = types,methods,properties,events
+# other valid values:
+# - types
+# - methods
+# - properties
+# - indexers
+# - events
+# - anonymous_methods
+# - control_blocks
+# - anonymous_types
+# - object_collection_array_initalizers
+# - lambdas
+# - local_functions

--- a/TensorFlowSharp.sln
+++ b/TensorFlowSharp.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26621.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TensorFlowSharp", "TensorFlowSharp\TensorFlowSharp.csproj", "{0264C321-34F4-46AF-819E-168D1E597232}"
 EndProject
@@ -23,6 +23,11 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TensorFlowSharp.Tests", "tests\TensorFlowSharp.Tests\TensorFlowSharp.Tests.fsproj", "{9EE13143-569F-4F7A-975A-DE7DF5C8FF0B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TensorFlowSharp.Tests.CSharp", "tests\TensorFlowSharp.Tests.CSharp\TensorFlowSharp.Tests.CSharp.csproj", "{6504A704-575C-48D0-A4D2-422A7010936B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{72E3A6DC-5772-4388-80C1-4164C2CE0242}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -76,6 +81,9 @@ Global
 		{5A493E1F-407D-4A3B-AF9B-A0F2930C1C18} = {674EC1D7-9649-462E-A7A8-93D0DE84FE64}
 		{9EE13143-569F-4F7A-975A-DE7DF5C8FF0B} = {6E72CAD1-7962-4256-AF2A-3B813FFC88EA}
 		{6504A704-575C-48D0-A4D2-422A7010936B} = {6E72CAD1-7962-4256-AF2A-3B813FFC88EA}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {19B7031D-FE57-405F-BC61-1C14F2D3DA61}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0


### PR DESCRIPTION
I am adding a [.editorconfig](https://github.com/editorconfig/editorconfig-visualstudio) respecting the code formatting used in this repository. This should prevent the unintended reformatting of entire files when pressing Ctrl+E, D or closing a curly bracket in Visual Studio 2017.