### PR TITLE
Adding clipping operations

### DIFF
--- a/TensorFlowSharp/OperationsExtras.cs
+++ b/TensorFlowSharp/OperationsExtras.cs
@@ -360,8 +360,8 @@ namespace TensorFlow
 		/// <returns>A clipped <see cref="TFOutput">tensor</see>.</returns>
 		public TFOutput ClipByValue (TFOutput x, TFOutput clip_value_min, TFOutput clip_value_max, string operName = null)
 		{
-            // https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/clip_ops.py#L33
-            var scopeName = MakeName ("ClipByValue", operName);
+			// https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/clip_ops.py#L33
+			var scopeName = MakeName ("ClipByValue", operName);
 			using (var newScope = WithScope (scopeName)) {
 				// Go through list of tensors, for each value in each tensor clip
 				var t_min = Minimum (x, clip_value_max);
@@ -389,8 +389,8 @@ namespace TensorFlow
 		/// <returns>A clipped <see cref="TFOutput">tensor</see>.</returns>
 		public TFOutput ClipByNorm (TFOutput x, TFOutput clip_norm, TFOutput? axes = null, string operName = null)
 		{
-            // https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/clip_ops.py#L73
-            var scopeName = MakeName ("ClipByNorm", operName);
+			// https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/clip_ops.py#L73
+			var scopeName = MakeName ("ClipByNorm", operName);
 			using (var newScope = WithScope (scopeName)) {
 				// Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
 				var l2norm_inv = Rsqrt (ReduceSum (Mul (x, x), axes, keep_dims: true));
@@ -416,8 +416,8 @@ namespace TensorFlow
 		/// <returns>A clipped <see cref="TFOutput">tensor</see>.</returns>
 		public TFOutput GlobalNorm (TFOutput [] tensors, string operName = null)
 		{
-            // https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/clip_ops.py#L122
-            var scopeName = MakeName ("GlobalNorm", operName);
+			// https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/clip_ops.py#L122
+			var scopeName = MakeName ("GlobalNorm", operName);
 			using (var newScope = WithScope (scopeName)) {
 				TFOutput [] half_squared_norms = new TFOutput [tensors.Length];
 
@@ -430,24 +430,24 @@ namespace TensorFlow
 			}
 		}
 
-        /// <summary>
-        /// Clips tensor values to a maximum average L2-norm.
-        /// </summary>
-        /// <remarks>
-        /// Given a tensor <paramref name="x"/>, and a maximum clip value <paramref name="clip_norm"/>, this operation 
-        /// normalizes <paramref name="x"/> so that its its average L2-norm is less than or equal to <paramref name="clip_norm"/>.
-        /// Specifically, if the average L2-norm is already less than or equal to <paramref name="clip_norm"/>, then <paramref name="x"/>
-        /// is not modified. If the average L2-norm is greater than <paramref name="clip_norm"/>, then this operation returns a tensor of the same
-        /// type and shape as <paramref name="x"/> with its values set to: <c>t* clip_norm / l2norm_avg(t)</c>. In this case, 
-        /// the average L2-norm of the output tensor is <paramref name="clip_norm"/>.
-        /// </remarks>
-        /// <param name="x">The input tensor.</param>
-        /// <param name="clip_norm">A maximum clipping value.</param>
-        /// <param name="operName">Name of the oper.</param>
-        public TFOutput ClipByAverageNorm (TFOutput x, TFOutput clip_norm, string operName = null)
+		/// <summary>
+		/// Clips tensor values to a maximum average L2-norm.
+		/// </summary>
+		/// <remarks>
+		/// Given a tensor <paramref name="x"/>, and a maximum clip value <paramref name="clip_norm"/>, this operation 
+		/// normalizes <paramref name="x"/> so that its its average L2-norm is less than or equal to <paramref name="clip_norm"/>.
+		/// Specifically, if the average L2-norm is already less than or equal to <paramref name="clip_norm"/>, then <paramref name="x"/>
+		/// is not modified. If the average L2-norm is greater than <paramref name="clip_norm"/>, then this operation returns a tensor of the same
+		/// type and shape as <paramref name="x"/> with its values set to: <c>t* clip_norm / l2norm_avg(t)</c>. In this case, 
+		/// the average L2-norm of the output tensor is <paramref name="clip_norm"/>.
+		/// </remarks>
+		/// <param name="x">The input tensor.</param>
+		/// <param name="clip_norm">A maximum clipping value.</param>
+		/// <param name="operName">Name of the oper.</param>
+		public TFOutput ClipByAverageNorm (TFOutput x, TFOutput clip_norm, string operName = null)
 		{
-            // https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/clip_ops.py#L251
-            var scopeName = MakeName ("ClipByAverageNorm", operName);
+			// https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/clip_ops.py#L251
+			var scopeName = MakeName ("ClipByAverageNorm", operName);
 			using (var newScope = WithScope (scopeName)) {
 				// Calculate L2-norm per element, clip elements by ratio of clip_norm to
 				// L2-norm per element
@@ -457,7 +457,7 @@ namespace TensorFlow
 
 				return tclip;
 			}
-        }
+		}
 
 
 
@@ -468,53 +468,53 @@ namespace TensorFlow
 
 
 
-        /// <summary>
-        /// Stacks a list of rank-`R` tensors into one rank-`(R+1)` tensor.
-        /// </summary>
-        /// <remarks>
-        ///  Packs the list of tensors in <paramref name="values"/> into a tensor with rank one higher than
-        ///  each tensor in <paramref name="values"/>, by packing them along the <paramref name="axis"/> dimension.
-        ///  Given a list of length <c>N</c> of tensors of shape </c>(A, B, C)</c>: if <c>axis == 0</c> then the 
-        ///  <c>output</c> tensor will have the shape <c>(N, A, B, C)</c>; if <c>axis == 1<c> then the <c>output<c>
-        ///  tensor will have the shape <c>(A, N, B, C)<c>; etc.
-        /// </remarks>
-        /// 
-        public TFOutput Stack(TFOutput[] values, int? axis = 0, string operName = "stack")
-        {
-            // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/array_ops.py#L804
+		/// <summary>
+		/// Stacks a list of rank-`R` tensors into one rank-`(R+1)` tensor.
+		/// </summary>
+		/// <remarks>
+		///  Packs the list of tensors in <paramref name="values"/> into a tensor with rank one higher than
+		///  each tensor in <paramref name="values"/>, by packing them along the <paramref name="axis"/> dimension.
+		///  Given a list of length <c>N</c> of tensors of shape </c>(A, B, C)</c>: if <c>axis == 0</c> then the 
+		///  <c>output</c> tensor will have the shape <c>(N, A, B, C)</c>; if <c>axis == 1<c> then the <c>output<c>
+		///  tensor will have the shape <c>(A, N, B, C)<c>; etc.
+		/// </remarks>
+		/// 
+		public TFOutput Stack (TFOutput [] values, int? axis = 0, string operName = "stack")
+		{
+			// https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/array_ops.py#L804
 
-            int ndims = GetTensorNumDims(values[0]);
+			int ndims = GetTensorNumDims (values [0]);
 
-            int expanded_num_dims = ndims + 1;
-            if (axis < -expanded_num_dims || axis >= expanded_num_dims)
-                throw new InvalidOperationException($"axis = {axis} not in [{-expanded_num_dims}, {expanded_num_dims}]");
+			int expanded_num_dims = ndims + 1;
+			if (axis < -expanded_num_dims || axis >= expanded_num_dims)
+				throw new InvalidOperationException ($"axis = {axis} not in [{-expanded_num_dims}, {expanded_num_dims}]");
 
-            return Pack(values, axis: axis, operName: operName);
-        }
+			return Pack (values, axis: axis, operName: operName);
+		}
 
-        /// <summary>
-        /// Creates a sequence of numbers.
-        /// </summary>
-        /// <remarks>
-        /// Creates a sequence of numbers that begins at `start` and extends by increments of `delta` up to but not including 
-        /// `limit`. The dtype of the resulting tensor is inferred from the inputs unless it is provided explicitly.
-        /// </remarks>
-        /// <param name="start">A 0 - D `Tensor` (scalar).Acts as first entry in the range if `limit` is not None; otherwise, acts as range limit and first entry defaults to 0.</param>
-        /// <param name="limit">A 0 - D `Tensor` (scalar).Upper limit of sequence, exclusive. If None, defaults to the value of `start` while the first entry of the range defaults to 0.</param>
-        /// <param name="delta">A 0 - D `Tensor` (scalar).Number that increments `start`. Defaults to 1.</param>
-        /// <param name="dataType">The type of the elements of the resulting tensor.</param>
-        /// <param name="operName">A name for the operation.Defaults to "range".</param>
-        public TFOutput Range (TFOutput start, TFOutput? limit = null, TFOutput? delta = null, TFDataType? dataType = null, string operName = "range")
+		/// <summary>
+		/// Creates a sequence of numbers.
+		/// </summary>
+		/// <remarks>
+		/// Creates a sequence of numbers that begins at `start` and extends by increments of `delta` up to but not including 
+		/// `limit`. The dtype of the resulting tensor is inferred from the inputs unless it is provided explicitly.
+		/// </remarks>
+		/// <param name="start">A 0 - D `Tensor` (scalar).Acts as first entry in the range if `limit` is not None; otherwise, acts as range limit and first entry defaults to 0.</param>
+		/// <param name="limit">A 0 - D `Tensor` (scalar).Upper limit of sequence, exclusive. If None, defaults to the value of `start` while the first entry of the range defaults to 0.</param>
+		/// <param name="delta">A 0 - D `Tensor` (scalar).Number that increments `start`. Defaults to 1.</param>
+		/// <param name="dataType">The type of the elements of the resulting tensor.</param>
+		/// <param name="operName">A name for the operation.Defaults to "range".</param>
+		public TFOutput Range (TFOutput start, TFOutput? limit = null, TFOutput? delta = null, TFDataType? dataType = null, string operName = "range")
 		{
 			// https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/python/ops/math_ops.py#L1156
 
 			if (limit == null) {
 				limit = start;
-				start = Cast(Const (new TFTensor (0.0)), start.OutputType); // TODO: Maybe add dataType as convenience in Const?
-            }
+				start = Cast (Const (new TFTensor (0.0)), start.OutputType); // TODO: Maybe add dataType as convenience in Const?
+			}
 
 			if (delta == null)
-				delta = Cast(Const (new TFTensor (1.0)), start.OutputType);
+				delta = Cast (Const (new TFTensor (1.0)), start.OutputType);
 
 			using (var newScope = WithScope (MakeName ("Range", operName))) {
 				// infer dtype if not explicitly provided

--- a/tests/TensorFlowSharp.Tests.CSharp/ArrayTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/ArrayTests.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Numerics;
+using TensorFlow;
+using Xunit;
+
+namespace TensorFlowSharp.Tests.CSharp
+{
+    public class ArrayTests
+    {
+
+        private static IEnumerable<object[]> stackData()
+        {
+            // Example from https://www.tensorflow.org/api_docs/python/tf/stack
+
+            // 'x' is [1, 4]
+            // 'y' is [2, 5]
+            // 'z' is [3, 6]
+
+            double[] x = { 1, 4 };
+            double[] y = { 2, 5 };
+            double[] z = { 3, 6 };
+
+            // stack([x, y, z]) => [[1, 4], [2, 5], [3, 6]]  // Pack along first dim.
+            // stack([x, y, z], axis= 1) => [[1, 2, 3], [4, 5, 6]]
+
+            yield return new object[] { x, y, z, null,  new double[,] { { 1, 4 },
+                                                                        { 2, 5 },
+                                                                        { 3, 6 } } };
+
+            yield return new object[] { x, y, z, 1, new double[,] { { 1, 2, 3 },
+                                                                    { 4, 5, 6 } } };
+        }
+
+        [Theory]
+        [MemberData(nameof(stackData))]
+        public void Should_Stack(double[] x, double[] y, double[] z, int? axis, double[,] expected)
+        {
+            using (var graph = new TFGraph())
+            using (var session = new TFSession(graph))
+            {
+                var a = graph.Placeholder(TFDataType.Double, new TFShape(2));
+                var b = graph.Placeholder(TFDataType.Double, new TFShape(2));
+                var c = graph.Placeholder(TFDataType.Double, new TFShape(2));
+
+                TFOutput r = graph.Stack(new[] { a, b, c }, axis: axis);
+
+                TFTensor[] result = session.Run(new[] { a, b, c }, new TFTensor[] { x, y, z }, new[] { r });
+
+                double[,] actual = (double[,])result[0].GetValue();
+                TestUtils.MatrixEqual(expected, actual, precision: 10);
+            }
+        }
+
+
+
+
+
+        private static IEnumerable<object[]> rangeData()
+        {
+            double[] x = { 1, 4 };
+            double[] y = { 2, 5 };
+            double[] z = { 3, 6 };
+
+            // 'start' is 3
+            // 'limit' is 18
+            // 'delta' is 3
+            //  tf.range(start, limit, delta) ==> [3, 6, 9, 12, 15]
+
+            // 'start' is 3
+            // 'limit' is 1
+            // 'delta' is -0.5
+            //  tf.range(start, limit, delta) ==> [3, 2.5, 2, 1.5]
+
+            // 'limit' is 5
+            //  tf.range(limit) ==> [0, 1, 2, 3, 4]
+
+            yield return new object[] { 3, 18, 3, new int[] { 3, 6, 9, 12, 15 } };
+            yield return new object[] { 3, 1, -0.5, new double[] { 3, 2.5, 2, 1.5 } };
+            yield return new object[] { 3, 1, -0.5f, new float[] { 3, 2.5f, 2, 1.5f } };
+            yield return new object[] { null, 5, null, new int[] { 0, 1, 2, 3, 4 } };
+            yield return new object[] { null, 5f, null, new float[] { 0, 1, 2, 3, 4f } };
+        }
+
+        [Theory]
+        [MemberData(nameof(rangeData))]
+        public void Should_Range(object start, object limit, object delta, object expected)
+        {
+            // Examples from https://www.tensorflow.org/api_docs/python/tf/range
+
+            using (var graph = new TFGraph())
+            using (var session = new TFSession(graph))
+            {
+                TFOutput tstart = graph.Placeholder(start == null ? TFDataType.Int32 : TensorTypeFromType(start.GetType()));
+                TFOutput tlimit = graph.Placeholder(limit == null ? TFDataType.Int32 : TensorTypeFromType(limit.GetType()));
+                TFOutput tdelta = graph.Placeholder(delta == null ? TFDataType.Int32 : TensorTypeFromType(delta.GetType()));
+
+                TFTensor[] result;
+                if (start == null && delta == null)
+                {
+                    TFOutput r = graph.Range(tlimit);
+                    result = session.Run(new[] { tlimit }, new TFTensor[] { TensorFromObject(limit) }, new[] { r });
+                }
+                else
+                {
+                    TFOutput r = graph.Range(tstart, (Nullable<TFOutput>)tlimit, (Nullable<TFOutput>)tdelta);
+                    result = session.Run(new[] { tstart, tlimit, tdelta },
+                        new TFTensor[] { TensorFromObject(start), TensorFromObject(limit), TensorFromObject(delta) },
+                        new[] { r });
+                }
+
+                Array actual = (Array)result[0].GetValue();
+                TestUtils.MatrixEqual((Array)expected, actual, precision: 10);
+            }
+        }
+
+        public static TFDataType TensorTypeFromType(Type type)
+        {
+            if (type == typeof(float))
+                return TFDataType.Float;
+            if (type == typeof(double))
+                return TFDataType.Double;
+            if (type == typeof(int))
+                return TFDataType.Int32;
+            if (type == typeof(byte))
+                return TFDataType.UInt8;
+            if (type == typeof(short))
+                return TFDataType.Int16;
+            if (type == typeof(sbyte))
+                return TFDataType.Int8;
+            if (type == typeof(String))
+                return TFDataType.String;
+            if (type == typeof(bool))
+                return TFDataType.Bool;
+            if (type == typeof(long))
+                return TFDataType.Int64;
+            if (type == typeof(ushort))
+                return TFDataType.UInt16;
+            if (type == typeof(Complex))
+                return TFDataType.Complex128;
+
+            throw new ArgumentOutOfRangeException("type");
+        }
+
+        public static TFTensor TensorFromObject(object obj)
+        {
+            Type type = obj.GetType();
+            if (type == typeof(float))
+                return new TFTensor((float)obj);
+            if (type == typeof(double))
+                return new TFTensor((double)obj);
+            if (type == typeof(int))
+                return new TFTensor((int)obj);
+            if (type == typeof(byte))
+                return new TFTensor((byte)obj);
+            if (type == typeof(short))
+                return new TFTensor((short)obj);
+            if (type == typeof(sbyte))
+                return new TFTensor((sbyte)obj);
+            if (type == typeof(String))
+                throw new NotImplementedException();
+            if (type == typeof(bool))
+                return new TFTensor((bool)obj);
+            if (type == typeof(long))
+                return new TFTensor((long)obj);
+            if (type == typeof(ushort))
+                return new TFTensor((ushort)obj);
+            if (type == typeof(Complex))
+                return new TFTensor((Complex)obj);
+
+            throw new ArgumentOutOfRangeException("type");
+        }
+    }
+}

--- a/tests/TensorFlowSharp.Tests.CSharp/ClipTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/ClipTests.cs
@@ -1,0 +1,277 @@
+﻿using System.Collections.Generic;
+using TensorFlow;
+using Xunit;
+
+namespace TensorFlowSharp.Tests.CSharp
+{
+    public class ClipTests
+    {
+        private static IEnumerable<object[]> clipByValueData()
+        {
+            yield return new object[]
+            {
+                new double[,]
+                {
+                    { 1, 2, 0 },
+                    { 4, -1, 7 }
+                },
+
+                1.0, 6.0,
+
+                new double[,]
+                {
+                    { 1, 2, 1 },
+                    { 4, 1, 6 }
+                }
+            };
+
+            yield return new object[]
+            {
+                new double[,]
+                {
+                    { -9, double.PositiveInfinity, double.NegativeInfinity },
+                    { 4, double.PositiveInfinity, 7 }
+                },
+
+                -2, 42,
+
+                new double[,]
+                {
+                    { -2, 42, -2 },
+                    { 4, 42, 7 }
+                }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(clipByValueData))]
+        public void Should_ClipByValue(double[,] m, double min, double max, double[,] expected)
+        {
+            using (var graph = new TFGraph())
+            using (var session = new TFSession(graph))
+            {
+                var matrix = graph.Placeholder(TFDataType.Double);
+                var clip_min = graph.Placeholder(TFDataType.Double);
+                var clip_max = graph.Const(new TFTensor(max));
+
+                TFOutput y = graph.ClipByValue(matrix, clip_min, clip_max);
+
+                TFTensor[] result = session.Run(new[] { matrix, clip_min }, new TFTensor[] { m, min }, new[] { y });
+
+                double[,] actual = (double[,])result[0].GetValue();
+                Assert.Equal(expected, actual);
+            }
+        }
+
+
+
+
+
+
+        private static IEnumerable<object[]> clipByNormData()
+        {
+            yield return new object[]
+            {
+                new double[,]
+                {
+                    { 1, 2, 0 },
+                    { 4, -1, 7 }
+                },
+
+                1.0, 0,
+
+                new double[,]
+                {
+                    { 0.24253562503633297, 0.89442719099991586, 0 },
+                    { 0.97014250014533188, -0.44721359549995793, 1 }
+                }
+            };
+
+            yield return new object[]
+            {
+                new double[,]
+                {
+                    { -9, 100, 0.1 },
+                    { 4, 0.4, 7 }
+                },
+
+                -2, 1,
+
+                new double[,]
+                {
+                    { -9, 100, 0.1 },
+                    { 4, 0.4, 7 }
+                }
+            };
+
+            yield return new object[]
+{
+                new double[,]
+                {
+                    { 1e-10, 1e-5, 1e-3 },
+                    { 1e-2, 0.0, 7.0 }
+                },
+
+                -2, 2,
+
+                null
+            };
+
+            yield return new object[]
+            {
+                new double[,]
+                {
+                    { -9, double.PositiveInfinity, double.NegativeInfinity },
+                    { 4, double.PositiveInfinity, 7 }
+                },
+
+                -2, -1,
+
+                new double[,]
+                {
+                    { -9, double.PositiveInfinity, double.NegativeInfinity },
+                    { 4, double.PositiveInfinity, 7 }
+                }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(clipByNormData))]
+        public void Should_ClipByNorm(double[,] m, double norm, int axis, double[,] expected)
+        {
+            using (var graph = new TFGraph())
+            using (var session = new TFSession(graph))
+            {
+                var matrix = graph.Placeholder(TFDataType.Double);
+                var clip_norm = graph.Placeholder(TFDataType.Double);
+                var a = graph.Const(new TFTensor(axis));
+
+                TFOutput y = graph.ClipByNorm(matrix, clip_norm, a);
+
+                if (expected != null)
+                {
+                    TFTensor[] result = session.Run(new[] { matrix, clip_norm }, new TFTensor[] { m, norm }, new[] { y });
+
+                    double[,] actual = (double[,])result[0].GetValue();
+                    MatrixEqual(expected, actual, precision: 10);
+                }
+                else
+                {
+                    Assert.Throws<TFException>(() => session.Run(new[] { matrix, clip_norm }, new TFTensor[] { m, norm }, new[] { y }));
+                }
+            }
+        }
+
+
+
+
+
+
+
+
+
+
+        private static IEnumerable<object[]> clipByAverageNormData()
+        {
+            yield return new object[]
+            {
+                new double[,]
+                {
+                    { 1, 2, 0 },
+                    { 4, -1, 7 }
+                },
+
+                1.0, 0,
+
+                new double[,]
+                {
+                    { 0.24253562503633297, 0.89442719099991586, 0 },
+                    { 0.97014250014533188, -0.44721359549995793, 1 }
+                }
+            };
+
+            yield return new object[]
+            {
+                new double[,]
+                {
+                    { -9, 100, 0.1 },
+                    { 4, 0.4, 7 }
+                },
+
+                -2, 1,
+
+                new double[,]
+                {
+                    { -9, 100, 0.1 },
+                    { 4, 0.4, 7 }
+                }
+            };
+
+            yield return new object[]
+{
+                new double[,]
+                {
+                    { 1e-10, 1e-5, 1e-3 },
+                    { 1e-2, 0.0, 7.0 }
+                },
+
+                -2, 2,
+
+                null
+            };
+
+            yield return new object[]
+            {
+                new double[,]
+                {
+                    { -9, double.PositiveInfinity, double.NegativeInfinity },
+                    { 4, double.PositiveInfinity, 7 }
+                },
+
+                -2, -1,
+
+                new double[,]
+                {
+                    { -9, double.PositiveInfinity, double.NegativeInfinity },
+                    { 4, double.PositiveInfinity, 7 }
+                }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(clipByAverageNormData))]
+        public void Should_ClipByAverageNorm(double[,] m, double norm, int axis, double[,] expected)
+        {
+            using (var graph = new TFGraph())
+            using (var session = new TFSession(graph))
+            {
+                var matrix = graph.Placeholder(TFDataType.Double);
+                var clip_norm = graph.Placeholder(TFDataType.Double);
+                var a = graph.Const(new TFTensor(axis));
+
+                TFOutput y = graph.ClipByNorm(matrix, clip_norm, a);
+
+                if (expected != null)
+                {
+                    TFTensor[] result = session.Run(new[] { matrix, clip_norm }, new TFTensor[] { m, norm }, new[] { y });
+
+                    double[,] actual = (double[,])result[0].GetValue();
+                    MatrixEqual(expected, actual, precision: 10);
+                }
+                else
+                {
+                    Assert.Throws<TFException>(() => session.Run(new[] { matrix, clip_norm }, new TFTensor[] { m, norm }, new[] { y }));
+                }
+            }
+        }
+
+
+
+        public static void MatrixEqual(double[,] expected, double[,] actual, int precision)
+        {
+            for (int i = 0; i < expected.GetLength(0); i++)
+                for (int j = 0; j < expected.GetLength(1); j++)
+                    Assert.Equal(expected[i, j], actual[i, j], precision: precision);
+        }
+    }
+}

--- a/tests/TensorFlowSharp.Tests.CSharp/ClipTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/ClipTests.cs
@@ -153,7 +153,7 @@ namespace TensorFlowSharp.Tests.CSharp
                     TFTensor[] result = session.Run(new[] { matrix, clip_norm }, new TFTensor[] { m, norm }, new[] { y });
 
                     double[,] actual = (double[,])result[0].GetValue();
-                    MatrixEqual(expected, actual, precision: 10);
+                    TestUtils.MatrixEqual(expected, actual, precision: 10);
                 }
                 else
                 {
@@ -256,7 +256,7 @@ namespace TensorFlowSharp.Tests.CSharp
                     TFTensor[] result = session.Run(new[] { matrix, clip_norm }, new TFTensor[] { m, norm }, new[] { y });
 
                     double[,] actual = (double[,])result[0].GetValue();
-                    MatrixEqual(expected, actual, precision: 10);
+                    TestUtils.MatrixEqual(expected, actual, precision: 10);
                 }
                 else
                 {
@@ -265,13 +265,5 @@ namespace TensorFlowSharp.Tests.CSharp
             }
         }
 
-
-
-        public static void MatrixEqual(double[,] expected, double[,] actual, int precision)
-        {
-            for (int i = 0; i < expected.GetLength(0); i++)
-                for (int j = 0; j < expected.GetLength(1); j++)
-                    Assert.Equal(expected[i, j], actual[i, j], precision: precision);
-        }
     }
 }

--- a/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
+++ b/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
@@ -60,9 +60,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArrayTests.cs" />
     <Compile Include="ClipTests.cs" />
     <Compile Include="BitwiseOperationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
+++ b/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
@@ -60,6 +60,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClipTests.cs" />
     <Compile Include="BitwiseOperationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tests/TensorFlowSharp.Tests.CSharp/TestUtils.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/TestUtils.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace TensorFlowSharp.Tests.CSharp
+{
+    public static class TestUtils
+    {
+        public static void MatrixEqual(double[,] expected, double[,] actual, int precision)
+        {
+            for (int i = 0; i < expected.GetLength(0); i++)
+                for (int j = 0; j < expected.GetLength(1); j++)
+                    Assert.Equal(expected[i, j], actual[i, j], precision: precision);
+        }
+
+        public static void MatrixEqual(Array expected, Array actual, int precision)
+        {
+            Assert.Equal(expected.Length, actual.Length);
+            Assert.Equal(expected.Rank, actual.Rank);
+            Assert.Equal(expected.GetType(), actual.GetType());
+
+            var ei = expected.GetEnumerator();
+            var ai = actual.GetEnumerator();
+
+            var expectedType = expected.GetType().GetElementType();
+
+            if (expectedType == typeof(double))
+            {
+                while (ei.MoveNext() && ai.MoveNext())
+                    Assert.Equal((double)ei.Current, (double)ai.Current, precision: 8);
+            }
+            else if (expectedType == typeof(float))
+            {
+                while (ei.MoveNext() && ai.MoveNext())
+                    Assert.Equal((float)ei.Current, (float)ai.Current, precision: 8);
+            }
+            else
+            {
+                while (ei.MoveNext() && ai.MoveNext())
+                    Assert.True(Object.Equals(ei.Current, ai.Current));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding clipping operations ClipByValue, ClipByNorm, GlobalNorm, and ClipByAverageNorm (after I couldn't find them in the current version - if they indeed existed, at least this served as an exercise :-) or otherwise the tests might be useful).

Also adding the convenience operations Stack (based on Pack) and Range (based on the original Range provided by TensorFlow C API).

The modified lines in the Dropout operation are because I have reformatted them to follow the same style as in the rest of the project (cf. #115). 