### PR TITLE
Add auto versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: csharp
 solution: TensorFlowSharp.sln
+install:
+  - git fetch --unshallow
 script:
   - wget "http://ci.tensorflow.org/view/Nightly/job/nightly-libtensorflow/TYPE=mac-slave/82/artifact/lib_package/libtensorflow-cpu-darwin-x86_64.tar.gz"
   - tar xzvf libtensorflow-cpu-darwin-x86_64.tar.gz lib/libtensorflow.so

--- a/TensorFlowSharp/Properties/AssemblyInfo.cs
+++ b/TensorFlowSharp/Properties/AssemblyInfo.cs
@@ -13,11 +13,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/TensorFlowSharp/TensorFlowSharp.csproj
+++ b/TensorFlowSharp/TensorFlowSharp.csproj
@@ -11,7 +11,6 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <ReleaseVersion>0.2</ReleaseVersion>
     <PackageId>TensorFlowSharp</PackageId>
-    <PackageVersion>1.3.0-pre1</PackageVersion>
     <Authors>Miguel de Icaza</Authors>
     <PackageLicenseUrl>https://github.com/migueldeicaza/TensorFlowSharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/migueldeicaza/TensorFlowSharp/</PackageProjectUrl>
@@ -19,7 +18,7 @@
     <Description>.NET Bindings for TensorFlow</Description>
     <Owners>Miguel de Icaza</Owners>
     <Summary>.NET API for TensorFlow, Google's Machine Intelligence framework</Summary>
-    <PackageReleaseNotes>Adds support for TensorFlor 1.3 - preview release</PackageReleaseNotes>
+    <PackageReleaseNotes>Adds support for TensorFlow 1.3 - preview release</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <_NativeFiles Include="..\native\*.*">
@@ -58,9 +57,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Tensorflow.cs" />
@@ -71,6 +67,10 @@
     <Compile Include="Tensor.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning">
+      <Version>2.0.37-beta</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="NuGet.Build.Packaging">
       <Version>*</Version>
       <PrivateAssets>all</PrivateAssets>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.3.0-preview.1.build.{height}",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master    
+    "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N
+  ],
+  "nugetPackageVersion":{
+    "semVer": 2
+  },
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true,
+      "setVersionVariables": true
+    }
+  }
+}

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
   "version": "1.3.0-preview.1.build.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master    
-    "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N
+    "^refs/heads/v\\d+\\.\\d+" // we also release branches starting with vN.N
   ],
   "nugetPackageVersion":{
     "semVer": 2


### PR DESCRIPTION
This adds auto-versioning based on @AArnott's [Nerdbank.Gitversioning](https://github.com/AArnott/Nerdbank.GitVersioning).

Every time you build, it'll bump the `{height}` parameter as in the `version.json` file. Use whatever format you want in there.

For non-release branches, it'll add the git hash in the version to disambiguate. For release branches (as defined in the `version.json`, it won't.

To do a release, remove the pre-release tag from the `version.json`, check it in and build. Then after your release, add the pre-release version back in. The purpose of this is to have complete build reproducibility. 

This will set the `Assembly*` versions and also the NuGet package version when you pack it.
