### PR TITLE
GH-180: Missing ReduceProd.

### DIFF
--- a/TensorFlowSharp/OperationsExtras.cs
+++ b/TensorFlowSharp/OperationsExtras.cs
@@ -64,6 +64,28 @@ namespace TensorFlow
 		}
 
 		/// <summary>
+		/// Computes the product of elements across dimensions of a tensor.
+		/// </summary>
+		/// <returns>The reduced tensor.</returns>
+		/// <param name="input">The tensor to reduce. Should have numeric type.</param>
+		/// <param name="axis">The dimensions to reduce. If not se (the default), reduces all dimensions.</param>
+		/// <param name="keep_dims">If set to <c>true</c> retains reduced dimensions with length 1.</param>
+		/// <param name="operName">A name for the operation, optional.</param>
+		/// <remarks>
+		///   Reduces input_tensor along the dimensions given in axis.
+		/// Unless keep_dims is true, the rank of the tensor is reduced by 1 for each
+		/// entry in axis. If keep_dims is true, the reduced dimensions
+		/// are retained with length 1.
+		/// 
+		/// If axis has no entries, all dimensions are reduced, and a
+		/// tensor with a single element is returned.
+		/// </remarks>
+		public TFOutput ReduceProd (TFOutput input, TFOutput? axis = null, bool? keep_dims = false, string operName = null)
+		{
+			return Prod (input, this.ReduceDims (input, axis), keep_dims, operName);
+		}
+
+		/// <summary>
 		/// Computes the mean of elements across dimensions of a tensor.
 		/// </summary>
 		/// <returns>The reduced tensor.</returns>
@@ -88,6 +110,7 @@ namespace TensorFlow
 				input = this.Cast (input, TFDataType.Int8);
 			return this.Mean (input, this.ReduceDims (input, axis), keep_dims, operName);
 		}
+
 
 		// Helper method to create a variable and track it.
 		Variable MakeVariable (TFOutput initialValue, bool trainable, string operName)

--- a/TensorFlowSharp/Tensorflow.cs
+++ b/TensorFlowSharp/Tensorflow.cs
@@ -3400,6 +3400,16 @@ namespace TensorFlow
 			Array.Copy (right.dims, 0, full, left.dims.Length, right.dims.Length);
 			return new TFShape (full);
 		}
+
+		/// <summary>
+		/// Performs an implicit conversion from <see cref="TFShape"/> to <see cref="TFTensor"/>.
+		/// </summary>
+		/// <param name="shape">The shape.</param>
+		/// <returns>The result of the conversion.</returns>
+		public static implicit operator TFTensor (TFShape shape)
+		{
+			return shape.AsTensor ();
+		}
 	}
 
 

--- a/tests/TensorFlowSharp.Tests.CSharp/ShapeTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/ShapeTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using TensorFlow;
+using Xunit;
+
+namespace TensorFlowSharp.Tests.CSharp
+{
+	public class ShapeTests
+	{
+		[Fact]
+		public void Should_ShapeAutomaticallyConvertToTensor ()
+		{
+			using (var graph = new TFGraph ())
+			using (var session = new TFSession (graph)) {
+
+				var x = graph.Const (new TFShape(2, 3));
+
+				TFTensor [] result = session.Run (new TFOutput [] { }, new TFTensor [] { }, new TFOutput [] { x });
+
+				int[] actual = (int[])result [0].GetValue ();
+				Assert.Equal (new [] { 2, 3 }, actual);
+			}
+		}
+
+	}
+}

--- a/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
+++ b/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <Compile Include="GradientTests.cs" />
     <Compile Include="ArrayTests.cs" />
+    <Compile Include="ShapeTests.cs" />
     <Compile Include="TensorTests.cs" />
     <Compile Include="ClipTests.cs" />
     <Compile Include="BitwiseOperationTests.cs" />

--- a/tests/TensorFlowSharp.Tests.CSharp/TestUtils.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/TestUtils.cs
@@ -56,6 +56,8 @@ namespace TensorFlowSharp.Tests.CSharp
 				Assert.Equal ((double)expected, (double)actual, precision: precision);
 			} else if (expectedType == typeof (float)) {
 				Assert.Equal ((float)expected, (float)actual, precision: precision);
+			} else if (expectedType == typeof (int)) {
+				Assert.Equal ((int)expected, (int)actual);
 			} else {
 				Assert.True (Object.Equals (expected, actual));
 			}


### PR DESCRIPTION
I am adding an implementation for ReduceProd (equivalent to TF's [reduce_prod](https://www.tensorflow.org/versions/r0.12/api_docs/python/math_ops/reduction#reduce_prod)).

I am also surreptitiously including a little change to make TFShape automatically convertible to TFTensor whenever possible (in the same way that [arrays are already convertible to TFTensor](https://github.com/migueldeicaza/TensorFlowSharp/blob/master/TensorFlowSharp/Tensor.cs#L635)).

Accepting this PR should solve #180.