### PR TITLE
Add preview ARM support in TensorFlowSharp using arm32/arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 packages/
 TestResults/
 
+native/
+
 # globs
 Makefile.in
 *.DS_Store

--- a/OpGenerator/OpGenerator.cs
+++ b/OpGenerator/OpGenerator.cs
@@ -636,7 +636,7 @@ class OpGenerator
 	void p (string fmt, params object [] args)
 	{
 		for (int i = 0; i < indent; i++)
-		     output.Write ("\t");
+			output.Write ("\t");
 		if (args.Length == 0)
 			output.WriteLine (fmt);
 		else
@@ -645,13 +645,8 @@ class OpGenerator
 
 	public static void Main (string [] args)
 	{
-		Console.WriteLine ("Getting code for {0}", GetVersion ());
-		if (Marshal.SizeOf (typeof (IntPtr)) != 8)
-			throw new Exception ("Need to run in 64");
 		if (args.Length == 0)
 			args = new string [] { "/cvs/tensorflow/tensorflow/core/api_def/base_api" };
-
-
 
 		new OpGenerator ().Run (args);
 	}

--- a/TensorFlowSharp/Tensor.cs
+++ b/TensorFlowSharp/Tensor.cs
@@ -1118,7 +1118,7 @@ namespace TensorFlow
 						data += sizeof (Complex);
 						break;
 					case TFDataType.String:
-						throw new NotImplementedException ("String decoding not implemented for tensor vecotrs yet");
+						throw new NotImplementedException ("String decoding not implemented for tensor vectors yet");
 					default:
 						throw new NotImplementedException ();
 					}

--- a/TensorFlowSharp/TensorFlowSharp.csproj
+++ b/TensorFlowSharp/TensorFlowSharp.csproj
@@ -32,11 +32,15 @@
   <ItemGroup>
     <None Remove="nuget\build\net45\TensorFlowSharp.targets" />
     <None Include="nuget\build\net45\TensorFlowSharp.targets" PackagePath="build\net45\TensorFlowSharp.targets" Pack="true" />
-    <None Include="..\native\libtensorflow.dll" Link="nuget\runtimes\win7-x64\native\libtensorflow.dll" PackagePath="runtimes\win7-x64\native\libtensorflow.dll" Pack="true" />
-    <None Include="..\native\libtensorflow.dylib" Link="nuget\runtimes\osx\native\libtensorflow.dylib" PackagePath="runtimes\osx\native\libtensorflow.dylib" Pack="true" />
-    <None Include="..\native\libtensorflow_framework.dylib" Link="nuget\runtimes\osx\native\libtensorflow_framework.dylib" PackagePath="runtimes\osx\native\libtensorflow_framework.dylib" Pack="true" />
-    <None Include="..\native\libtensorflow.so" Link="nuget\runtimes\linux\native\libtensorflow.so" PackagePath="runtimes\linux\native\libtensorflow.so" Pack="true" />
-    <None Include="..\native\libtensorflow_framework.so" Link="nuget\runtimes\linux\native\libtensorflow_framework.so" PackagePath="runtimes\linux\native\libtensorflow_framework.so" Pack="true" />
+    <None Include="..\native\win7-x64\libtensorflow.dll" Link="nuget\runtimes\win7-x64\native\libtensorflow.dll" PackagePath="runtimes\win7-x64\native\libtensorflow.dll" Pack="true" />
+    <None Include="..\native\osx\libtensorflow.dylib" Link="nuget\runtimes\osx\native\libtensorflow.dylib" PackagePath="runtimes\osx\native\libtensorflow.dylib" Pack="true" />
+    <None Include="..\native\osx\libtensorflow_framework.dylib" Link="nuget\runtimes\osx\native\libtensorflow_framework.dylib" PackagePath="runtimes\osx\native\libtensorflow_framework.dylib" Pack="true" />
+    <None Include="..\native\linux-x64\libtensorflow.so" Link="nuget\runtimes\linux-x64\native\libtensorflow.so" PackagePath="runtimes\linux-x64\native\libtensorflow.so" Pack="true" />
+    <None Include="..\native\linux-x64\libtensorflow_framework.so" Link="nuget\runtimes\linux-x64\native\libtensorflow_framework.so" PackagePath="runtimes\linux-x64\native\libtensorflow_framework.so" Pack="true" />
+    <None Include="..\native\linux-arm\libtensorflow.so" Link="nuget\runtimes\linux-arm\native\libtensorflow.so" PackagePath="runtimes\linux-arm\native\libtensorflow.so" Pack="true" />
+    <None Include="..\native\linux-arm\libtensorflow_framework.so" Link="nuget\runtimes\linux-arm\native\libtensorflow_framework.so" PackagePath="runtimes\linux-arm\native\libtensorflow_framework.so" Pack="true" />
+    <None Include="..\native\linux-arm64\libtensorflow.so" Link="nuget\runtimes\linux-arm64\native\libtensorflow.so" PackagePath="runtimes\linux-arm64\native\libtensorflow.so" Pack="true" />
+    <None Include="..\native\linux-arm64\libtensorflow_framework.so" Link="nuget\runtimes\linux-arm64\native\libtensorflow_framework.so" PackagePath="runtimes\linux-arm64\native\libtensorflow_framework.so" Pack="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TensorFlowSharp/Tensorflow.cs
+++ b/TensorFlowSharp/Tensorflow.cs
@@ -46,8 +46,6 @@ namespace TensorFlow
 		public const string TensorFlowLibraryGPU = "libtensorflowgpu";
 
 		internal static string GetStr (this IntPtr x) => Marshal.PtrToStringAnsi (x);
-
-
 	}
 
 	/// <summary>
@@ -58,16 +56,6 @@ namespace TensorFlow
 		
 		[DllImport (NativeBinding.TensorFlowLibrary)]
 		static extern unsafe IntPtr TF_Version ();
-
-		static TFCore ()
-		{
-			Init ();
-		}
-
-		internal static void Init ()
-		{
-			CheckSize ();
-		}
 
 		/// <summary>
 		/// Returns the version of the TensorFlow runtime in use.
@@ -99,22 +87,6 @@ namespace TensorFlow
 		{
 			return new TFBuffer (TF_GetAllOpList ());
 		}
-
-		static void CheckSize ()
-		{
-			unsafe
-			{
-				if (sizeof (IntPtr) == 4) {
-					Console.Error.WriteLine (
-						"The TensorFlow native libraries were compiled in 64 bit mode, you must run in 64 bit mode\n" +
-						"With Mono, do that with mono --arch=64 executable.exe, if using an IDE like MonoDevelop,\n" +
-						"Xamarin Studio or Visual Studio for Mac, Build/Compiler settings, make sure that " +
-						"\"Platform Target\" has x64 selected.");
-					throw new Exception ();
-
-				}
-			}
-		}
 	}
 
 	/// <summary>
@@ -139,11 +111,6 @@ namespace TensorFlow
 		/// </summary>
 		/// <value>The handle.</value>
 		public IntPtr Handle => handle;
-
-		static TFDisposable ()
-		{
-			TFCore.Init ();
-		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="T:TensorFlow.TFDisposable"/> class.

--- a/TensorFlowSharp/nuget/build/net45/TensorFlowSharp.targets
+++ b/TensorFlowSharp/nuget/build/net45/TensorFlowSharp.targets
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<PropertyGroup>
-		<IsOSX Condition="Exists('/Library/Frameworks') and Exists ('/etc')">true</IsOSX>
-		<IsLinux Condition="Exists ('/proc') and Exists ('/etc/')">true</IsLinux>
-
-		<!-- if ShouldIncludeNativeTensorFlow == False then don't include the native libraries -->
-		<ShouldIncludeNativeTensorFlow Condition=" '$(ShouldIncludeNativeTensorFlow)' == '' ">True</ShouldIncludeNativeTensorFlow>
-	</PropertyGroup>
-
-	<ItemGroup Condition=" '$(ShouldIncludeNativeTensorFlow)' != 'False' ">
-		<None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux\native\**\*" Condition="'$(IsLinux)' == 'true'">
+	<ItemGroup>
+		<None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\**\*">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
-		<None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\**\*" Condition="'$(IsOSX)' == 'true'">
+		<None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm\native\**\*">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
-		<None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x64\native\**\*" Condition="'$(OS)' != 'Unix'">
+		<None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\**\*">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\**\*">
+			<Link>%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x64\native\**\*">
 			<Link>%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>


### PR DESCRIPTION
- Remove 64-bit checks from code to support this.
- Add linux-arm/linux-arm64 specific binaries of libtensorflow.so/libtensorflow_framework.so to the Nuget package.

See this repo for instructions on cross-compiling Tensorflow for arm from source:
https://github.com/jessebenson/tensorflow-on-arm