### PR TITLE
Add missing MonoPInvokeCallback attribute to FreeTensorHandle

### DIFF
--- a/TensorFlowSharp/Tensor.cs
+++ b/TensorFlowSharp/Tensor.cs
@@ -85,6 +85,7 @@ namespace TensorFlow
 			Marshal.FreeHGlobal (data);
 		}
 
+		[MonoPInvokeCallback (typeof (Deallocator))]
 		internal static void FreeTensorHandle (IntPtr data, IntPtr len, IntPtr closure)
 		{
 			var gch = GCHandle.FromIntPtr (closure);


### PR DESCRIPTION
Without this attribute, on iOS device builds, the following exception is thrown:

System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.ExecutionEngineException: Attempting to JIT compile method '(wrapper native-to-managed) TensorFlow.TFTensor:FreeTensorHandle (intptr,intptr,intptr)' while running in aot-only mode. See https://developer.xamarin.com/guides/ios/advanced_topics/limitations/ for more information.