### PR TITLE
Visual Studio 2017

### DIFF
--- a/OpGenerator/OpGenerator.cs
+++ b/OpGenerator/OpGenerator.cs
@@ -26,13 +26,13 @@ class ApiDefMap : IDisposable
 {
 	public class Status : IDisposable
 	{
-		[DllImport ("libtensorflow")]
+		[DllImport ("tensorflow")]
 		static extern unsafe IntPtr TF_NewStatus ();
 
-		[DllImport ("libtensorflow")]
+		[DllImport ("tensorflow")]
 		internal static extern unsafe void TF_DeleteStatus (IntPtr status);
 
-		[DllImport ("libtensorflow")]
+		[DllImport ("tensorflow")]
 		static extern unsafe int TF_GetCode (IntPtr s);
 
 		IntPtr handle;
@@ -56,16 +56,16 @@ class ApiDefMap : IDisposable
 		}
 	}
 
-	[DllImport ("libtensorflow")]
+	[DllImport ("tensorflow")]
 	unsafe extern static IntPtr TF_NewApiDefMap (IntPtr buffer, IntPtr status);
 
-	[DllImport ("libtensorflow")]
+	[DllImport ("tensorflow")]
 	static extern void TF_DeleteApiDefMap (IntPtr handle);
 
-	[DllImport ("libtensorflow")]
+	[DllImport ("tensorflow")]
 	static extern void TF_ApiDefMapPut (IntPtr handle, string text, IntPtr textLen, IntPtr status);
 
-	[DllImport ("libtensorflow")]
+	[DllImport ("tensorflow")]
 	unsafe static extern OpGenerator.LLBuffer *TF_ApiDefMapGet (IntPtr handle, string name, IntPtr nameLen, IntPtr status);
 
 	IntPtr handle;
@@ -127,7 +127,7 @@ class ApiDefMap : IDisposable
 
 class OpGenerator
 {
-	[DllImport ("libtensorflow")]
+	[DllImport ("tensorflow")]
 	static extern unsafe IntPtr TF_Version ();
 
 	public static string GetVersion ()
@@ -536,7 +536,7 @@ class OpGenerator
 		internal IntPtr data_deallocator;
 	}
 
-	[DllImport ("libtensorflow")]
+	[DllImport ("tensorflow")]
 	unsafe extern static LLBuffer *TF_GetAllOpList ();
 	ApiDefMap apimap;
 

--- a/TensorFlowSharp/Tensorflow.cs
+++ b/TensorFlowSharp/Tensorflow.cs
@@ -42,8 +42,8 @@ namespace TensorFlow
 {
 	static partial class NativeBinding
 	{
-		public const string TensorFlowLibrary = "libtensorflow";
-		public const string TensorFlowLibraryGPU = "libtensorflowgpu";
+		public const string TensorFlowLibrary = "tensorflow";
+		public const string TensorFlowLibraryGPU = "tensorflowgpu";
 
 		internal static string GetStr (this IntPtr x) => Marshal.PtrToStringAnsi (x);
 

--- a/tests/TensorFlowSharp.Tests.CSharp/ArrayTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/ArrayTests.cs
@@ -155,7 +155,7 @@ namespace TensorFlowSharp.Tests.CSharp
 		}
 #endif
 
-        private static IEnumerable<object[]> stackData()
+        public static IEnumerable<object[]> stackData()
         {
             // Example from https://www.tensorflow.org/api_docs/python/tf/stack
 
@@ -198,7 +198,7 @@ namespace TensorFlowSharp.Tests.CSharp
             }
         }
 
-        private static IEnumerable<object[]> rangeData()
+		public static IEnumerable<object[]> rangeData()
         {
             double[] x = { 1, 4 };
             double[] y = { 2, 5 };
@@ -257,7 +257,7 @@ namespace TensorFlowSharp.Tests.CSharp
         }
 
 
-		private static IEnumerable<object []> transposeData ()
+		public static IEnumerable<object []> transposeData ()
 		{
 			yield return new object [] { new double [,] { { 1, 2 },
 														  { 3, 4 } }};

--- a/tests/TensorFlowSharp.Tests.CSharp/ClipTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/ClipTests.cs
@@ -6,7 +6,7 @@ namespace TensorFlowSharp.Tests.CSharp
 {
     public class ClipTests
     {
-        private static IEnumerable<object[]> clipByValueData()
+        public static IEnumerable<object[]> clipByValueData()
         {
             yield return new object[]
             {
@@ -68,7 +68,7 @@ namespace TensorFlowSharp.Tests.CSharp
 
 
 
-        private static IEnumerable<object[]> clipByNormData()
+		public static IEnumerable<object[]> clipByNormData()
         {
             yield return new object[]
             {
@@ -171,7 +171,7 @@ namespace TensorFlowSharp.Tests.CSharp
 
 
 
-        private static IEnumerable<object[]> clipByAverageNormData()
+		public static IEnumerable<object[]> clipByAverageNormData()
         {
             yield return new object[]
             {

--- a/tests/TensorFlowSharp.Tests.CSharp/MathTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/MathTests.cs
@@ -29,7 +29,7 @@ namespace TensorFlowSharp.Tests.CSharp
 			}
 		}
 
-		private static IEnumerable<object []> reduceMeanData ()
+		public static IEnumerable<object []> reduceMeanData ()
 		{
 			// Example from https://www.tensorflow.org/api_docs/python/tf/reduce_mean
 			// # 'x' is [[1., 1.]
@@ -72,7 +72,7 @@ namespace TensorFlowSharp.Tests.CSharp
 			}
 		}
 
-		private static IEnumerable<object []> sigmoidCrossEntropyData ()
+		public static IEnumerable<object []> sigmoidCrossEntropyData ()
 		{
 			yield return new object [] { new [] { 1.0, 0.0, 1.0, 1.0 }, new [] { 1.0, 0.0, 1.0, 1.0 }, new [] { 0.31326168751822281, 0.69314718055994529, 0.31326168751822281, 0.31326168751822281 } };
 			yield return new object [] { new [] { 1.0, 0.0, 1.0, 1.0 }, new [] { -0.2, 4.2, 0.0, 0.0 }, new [] { 0.79813886938159184, 4.2148842546719187, 0.69314718055994529, 0.69314718055994529 } };
@@ -101,7 +101,7 @@ namespace TensorFlowSharp.Tests.CSharp
 			}
 		}
 
-		private static IEnumerable<object []> reduceProdData ()
+		public static IEnumerable<object []> reduceProdData ()
 		{
 			// Example from https://www.tensorflow.org/api_docs/python/tf/reduce_mean but adapted to return prod
 			var x = new double [,] { { 1, 1 },
@@ -138,7 +138,7 @@ namespace TensorFlowSharp.Tests.CSharp
 			}
 		}
 
-		private static IEnumerable<object []> reduceProdData2 ()
+		public static IEnumerable<object []> reduceProdData2 ()
 		{
 			yield return new object [] { null, 170170.0 };
 			yield return new object [] { -3, new [] { 1.0 } };

--- a/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
+++ b/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.3.0-beta3-build3705\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.3.0-beta3-build3705\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props" Condition="Exists('..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" />
+  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -53,14 +55,14 @@
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -90,11 +92,18 @@
       <Name>TensorFlowSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.3.0-beta3-build3705\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.3.0-beta3-build3705\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
 </Project>

--- a/tests/TensorFlowSharp.Tests.CSharp/TensorTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/TensorTests.cs
@@ -7,7 +7,7 @@ namespace TensorFlowSharp.Tests.CSharp
 {
 	public class TensorTests
 	{
-		private static IEnumerable<object []> jaggedData ()
+		public static IEnumerable<object []> jaggedData ()
 		{
 			yield return new object [] {
 				new double [][] { new [] { 1.0, 2.0 }, new [] { 3.0, 4.0 } },

--- a/tests/TensorFlowSharp.Tests.CSharp/packages.config
+++ b/tests/TensorFlowSharp.Tests.CSharp/packages.config
@@ -3,12 +3,13 @@
   <package id="Microsoft.DotNet.InternalAbstractions" version="1.0.500-preview2-1-003177" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.TestHost" version="15.3.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
-  <package id="xunit" version="2.2.0" targetFramework="net461" />
+  <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
-  <package id="xunit.assert" version="2.2.0" targetFramework="net461" />
-  <package id="xunit.core" version="2.2.0" targetFramework="net461" />
-  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
-  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
-  <package id="xunit.runner.console" version="2.2.0" targetFramework="net461" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.3.0-beta3-build3705" targetFramework="net461" developmentDependency="true" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.core" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.runner.console" version="2.3.1" targetFramework="net461" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/tests/TensorFlowSharp.Tests/TensorFlowSharp.Tests.fsproj
+++ b/tests/TensorFlowSharp.Tests/TensorFlowSharp.Tests.fsproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props" Condition="Exists('..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" />
+  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -76,24 +78,30 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit.assert">
-      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
     <Reference Include="xunit.console">
       <HintPath>..\..\packages\xunit.runner.console.2.2.0\tools\xunit.console.exe</HintPath>
     </Reference>
     <Reference Include="xunit.core">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
     <Reference Include="xunit.execution.desktop">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="xunit.runner.reporters.net452">
       <HintPath>..\..\packages\xunit.runner.console.2.2.0\tools\xunit.runner.reporters.net452.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props'))" />
+  </Target>
+  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/TensorFlowSharp.Tests/packages.config
+++ b/tests/TensorFlowSharp.Tests/packages.config
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.2.0" targetFramework="net461" />
+  <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
-  <package id="xunit.assert" version="2.2.0" targetFramework="net461" />
-  <package id="xunit.core" version="2.2.0" targetFramework="net461" />
-  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
-  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
-  <package id="xunit.runner.console" version="2.2.0" targetFramework="net461" developmentDependency="true" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.core" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net461" />
+  <package id="xunit.runner.console" version="2.3.1" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
To be able to run the unit tests on VS2017 I had to do the following:
- Upgrade xUnit to the latest version (I was having a conflict with runners).
- Remove "lib" from the name used in DllImport. ([It's automatically added when on unix-based system](http://www.mono-project.com/docs/advanced/pinvoke/#library-names)).