### PR TITLE
Add missing unit tests to unit test project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 solution: TensorFlowSharp.sln
 script:
-  - tsh_version=1.4.0-pre1
+  - tsh_version=1.10.0
   - wget "https://www.nuget.org/api/v2/package/TensorFlowSharp/$tsh_version"
   - tar xzvf $tsh_version native
   - msbuild /t:Restore $TRAVIS_BUILD_DIR/TensorFlowSharp.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ script:
   - tsh_version=1.10.0
   - wget "https://www.nuget.org/api/v2/package/TensorFlowSharp/$tsh_version"
   - tar xzvf $tsh_version runtimes
+  - mkdir $TRAVIS_BUILD_DIR/native
   - cp -R $TRAVIS_BUILD_DIR/runtimes/linux/native/* $TRAVIS_BUILD_DIR/native/
   - cp -R $TRAVIS_BUILD_DIR/runtimes/osx/native/* $TRAVIS_BUILD_DIR/native/
   - cp -R $TRAVIS_BUILD_DIR/runtimes/win7-x64/native/* $TRAVIS_BUILD_DIR/native/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ solution: TensorFlowSharp.sln
 script:
   - tsh_version=1.10.0
   - wget "https://www.nuget.org/api/v2/package/TensorFlowSharp/$tsh_version"
-  - tar xzvf $tsh_version native
+  - tar xzvf $tsh_version runtimes
   - msbuild /t:Restore $TRAVIS_BUILD_DIR/TensorFlowSharp.sln
   - cd $TRAVIS_BUILD_DIR/
   - msbuild /p:Configuration=Release TensorFlowSharp.sln
-  - cp -R $TRAVIS_BUILD_DIR/native/*.dylib $TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests/bin/Release/
-  - cp -R $TRAVIS_BUILD_DIR/native/*.dylib $TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests.CSharp/bin/Release/
+  - cp -R $TRAVIS_BUILD_DIR/runtimes/osx/native/*.dylib $TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests/bin/Release/
+  - cp -R $TRAVIS_BUILD_DIR/runtimes/osx/native/*.dylib $TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests.CSharp/bin/Release/
   - cd $TRAVIS_BUILD_DIR/packages/xunit.runner.console.2.2.0/tools
   - cp "$TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests/obj/Release/FSharp.Core.dll" .
   - mono --arch=64 xunit.console.exe "$TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests/bin/Release/TensorFlowSharp.Tests.dll" "$TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests.CSharp/bin/Release/TensorFlowSharp.Tests.CSharp.dll"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@ script:
   - tsh_version=1.10.0
   - wget "https://www.nuget.org/api/v2/package/TensorFlowSharp/$tsh_version"
   - tar xzvf $tsh_version runtimes
+  - cp -R $TRAVIS_BUILD_DIR/runtimes/linux/native/* $TRAVIS_BUILD_DIR/native/
+  - cp -R $TRAVIS_BUILD_DIR/runtimes/osx/native/* $TRAVIS_BUILD_DIR/native/
+  - cp -R $TRAVIS_BUILD_DIR/runtimes/win7-x64/native/* $TRAVIS_BUILD_DIR/native/
   - msbuild /t:Restore $TRAVIS_BUILD_DIR/TensorFlowSharp.sln
   - cd $TRAVIS_BUILD_DIR/
   - msbuild /p:Configuration=Release TensorFlowSharp.sln
-  - cp -R $TRAVIS_BUILD_DIR/runtimes/osx/native/*.dylib $TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests/bin/Release/
-  - cp -R $TRAVIS_BUILD_DIR/runtimes/osx/native/*.dylib $TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests.CSharp/bin/Release/
+  - cp -R $TRAVIS_BUILD_DIR/native/*.dylib $TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests/bin/Release/
+  - cp -R $TRAVIS_BUILD_DIR/native/*.dylib $TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests.CSharp/bin/Release/
   - cd $TRAVIS_BUILD_DIR/packages/xunit.runner.console.2.2.0/tools
   - cp "$TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests/obj/Release/FSharp.Core.dll" .
   - mono --arch=64 xunit.console.exe "$TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests/bin/Release/TensorFlowSharp.Tests.dll" "$TRAVIS_BUILD_DIR/tests/TensorFlowSharp.Tests.CSharp/bin/Release/TensorFlowSharp.Tests.CSharp.dll"

--- a/TensorFlowSharp/OperationsExtras.cs
+++ b/TensorFlowSharp/OperationsExtras.cs
@@ -119,7 +119,7 @@ namespace TensorFlow
 
 			using (var newScope = WithScope (scopeName)) {
 				var type = initialValue.OutputType;
-				var variableHandle = VarHandleOp (type, new TFShape (GetShape (initialValue)));
+				var variableHandle = VarHandleOp (type, new TFShape (GetShape (initialValue)), shared_name: scopeName);
 				using (var aScope = WithScope ("Assign")) {
 					var assignOp = AssignVariableOp (variableHandle, initialValue);
 					using (var rScope = WithScope ("Read")) {

--- a/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
+++ b/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
@@ -77,6 +77,7 @@
     <Compile Include="PartialRunTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestUtils.cs" />
+    <Compile Include="GettingStarted.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
I realised why the 'GettingStarted.cs' tests were not running as part of the unit test project. Just needed to add it into the .csproj file.