### PR TITLE
Ignore missing TF_GraphDebugString

### DIFF
--- a/TensorFlowSharp/Tensorflow.cs
+++ b/TensorFlowSharp/Tensorflow.cs
@@ -1399,7 +1399,14 @@ namespace TensorFlow
 		public override string ToString ()
 		{
 	    		IntPtr len;
-	    		return TF_GraphDebugString (Handle, out len);
+			try
+			{
+				return TF_GraphDebugString (Handle, out len);
+			}
+			catch (System.EntryPointNotFoundException)
+			{
+				return "Your Tensorflow version does not support GraphDebugString";
+			}
 		}
     	}
 


### PR DESCRIPTION
Some TF DLL versions don't have TF_GraphDebugString. Ignoring the error in debug calls.