### PR TITLE
Number of dims for shape list isn't set

### DIFF
--- a/TensorFlowSharp/Tensorflow.cs
+++ b/TensorFlowSharp/Tensorflow.cs
@@ -1917,7 +1917,8 @@ namespace TensorFlow
 					IntPtr array = Marshal.AllocHGlobal (sizeof (long) * shapeList [i].dims.Length);
 					Marshal.Copy (shapeList [i].dims, 0, array, shapeList [i].dims.Length);
 					Marshal.WriteIntPtr (unmanaged, ofs, array);
-					ofs += sizeof (IntPtr);
+				    num_dims[i] = shapeList[i].NumDimensions;
+                    ofs += sizeof (IntPtr);
 				}
 				TF_SetAttrShapeList (handle, attrName, unmanaged, num_dims, num_shapes);
 				ofs = 0;


### PR DESCRIPTION
The number of dims for shape list isn't set.  This prevents operations for datasets and iterators from working with anything other than scalar shapes