### PR TITLE
Setting variable shared_name property to avoid variables sharing.

### DIFF
--- a/TensorFlowSharp/OperationsExtras.cs
+++ b/TensorFlowSharp/OperationsExtras.cs
@@ -119,7 +119,7 @@ namespace TensorFlow
 
 			using (var newScope = WithScope (scopeName)) {
 				var type = initialValue.OutputType;
-				var variableHandle = VarHandleOp (type, new TFShape (GetShape (initialValue)));
+				var variableHandle = VarHandleOp (type, new TFShape (GetShape (initialValue)), shared_name: operName);
 				using (var aScope = WithScope ("Assign")) {
 					var assignOp = AssignVariableOp (variableHandle, initialValue);
 					using (var rScope = WithScope ("Read")) {
@@ -208,22 +208,22 @@ namespace TensorFlow
 			return res;
 		}
 
-		/// <summary>
-		/// Variable node, with a starting initial value.  Convenience that registers the init variable to a global queue.
-		/// </summary>
-		/// <param name="initialValue">Initial value.</param>
-		/// <param name="value">Returns the value of the variable.</param>
-		/// <param name="trainable">If true, this add the variable to the graph's TrainableVariables, this collection is intended to be used by the Optimizer classes.</param>
-		/// <param name="operName">Operation name, optional.</param>
-		/// <returns>The returning Variable contains the variable, with three nodes with the operations making up the variable assignment.</returns>
-		/// <remarks>
-		/// Variables need to be initialized before the main execution so you will typically want to
-		/// run the session on the variable.
-		/// 
-		/// The init sequence for the variable is stored in the graph, you must manually initialize 
-		/// those by running the session on the global variables.
-		/// </remarks>
-		public Variable Variable (TFOutput initialValue, out TFOutput value, bool trainable = true, string operName = null)
+        /// <summary>
+        /// Variable node, with a starting initial value.  Convenience that registers the init variable to a global queue.
+        /// </summary>
+        /// <param name="initialValue">Initial value.</param>
+        /// <param name="value">Returns the value of the variable.</param>
+        /// <param name="trainable">If true, this add the variable to the graph's TrainableVariables, this collection is intended to be used by the Optimizer classes.</param>
+        /// <param name="operName">Operation name, optional.</param>
+        /// <returns>The returning Variable contains the variable, with three nodes with the operations making up the variable assignment.</returns>
+        /// <remarks>
+        /// Variables need to be initialized before the main execution so you will typically want to
+        /// run the session on the variable.
+        /// 
+        /// The init sequence for the variable is stored in the graph, you must manually initialize 
+        /// those by running the session on the global variables.
+        /// </remarks>
+        public Variable Variable (TFOutput initialValue, out TFOutput value, bool trainable = true, string operName = null)
 		{
 			var nv = MakeVariable (initialValue, trainable, operName);
 			value = nv.Read;

--- a/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
+++ b/tests/TensorFlowSharp.Tests.CSharp/TensorFlowSharp.Tests.CSharp.csproj
@@ -25,7 +25,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile></DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,7 +35,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AssemblyName></AssemblyName>
+    <AssemblyName>
+    </AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.DotNet.InternalAbstractions, Version=1.0.500.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -79,6 +81,7 @@
     <Compile Include="PartialRunTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestUtils.cs" />
+    <Compile Include="VariableTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/TensorFlowSharp.Tests.CSharp/VariableTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/VariableTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using TensorFlow;
+using Xunit;
+
+
+namespace TensorFlowSharp.Tests.CSharp
+{
+    public class VariableTests
+    {
+        [Fact]
+        public void ShouldNotShareVariablesSameType()
+        {
+            using (var graph = new TFGraph())
+            {
+                var v1 = graph.Variable(graph.Const(0.5f), operName: "v1");
+                var v2 = graph.Variable(graph.Const(0.6f), operName: "v2");
+
+                using (var session = new TFSession(graph))
+                {
+                    var result = session.GetRunner().AddTarget(graph.GetGlobalVariablesInitializer()).Fetch(v1.Read, v2.Read).Run();
+                    Assert.NotEqual(result[0].GetValue(), result[1].GetValue());
+                }
+            }
+        }
+
+        [Fact]
+        public void ShouldNotShareVariablesDifferentType()
+        {
+            using (var graph = new TFGraph())
+            {
+                var v1 = graph.Variable(graph.Const(0.5f), operName: "v1");
+                var v2 = graph.Variable(graph.Const(0L), operName: "v2");
+
+                using (var session = new TFSession(graph))
+                {
+                    var result = session.GetRunner().AddTarget(graph.GetGlobalVariablesInitializer()).Fetch(v1.Read, v2.Read).Run();
+                    Assert.NotEqual(result[0].TensorType, result[1].TensorType);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/migueldeicaza/TensorFlowSharp/issues/395.