### PR TITLE
Runner.AddTarget will no longer throw NullReferenceException

### DIFF
--- a/TensorFlowSharp/Tensorflow.cs
+++ b/TensorFlowSharp/Tensorflow.cs
@@ -2929,14 +2929,28 @@ namespace TensorFlow
 			// Parses user strings that contain both the operation name and an index.
 			TFOutput ParseOutput (string operation)
 			{
+				TFOperation tfOperation;
 				var p = operation.IndexOf (':');
-				if (p != -1 && p != operation.Length - 1){
+				if (p != -1 && p != operation.Length - 1)
+				{
+					
 					var op = operation.Substring (0, p);
-					if (int.TryParse (operation.Substring (p + 1), out var idx)){
-						return session.Graph [op] [idx];
+					if (int.TryParse (operation.Substring (p + 1), out var idx))
+					{
+						tfOperation = session.Graph [op];
+						if (tfOperation == null)
+						{
+							throw new ArgumentOutOfRangeException($"An operation named {op} is not in this graph.");
+						}
+						return tfOperation [idx];
 					}
 				}
-				return session.Graph [operation] [0];
+				tfOperation = session.Graph [operation];
+				if (tfOperation == null)
+				{
+					throw new ArgumentOutOfRangeException($"An operation named {operation} is not in this graph.");
+				}
+				return tfOperation [0];
 			}
 
 			/// <summary>

--- a/tests/TensorFlowSharp.Tests.CSharp/SessionTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/SessionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using TensorFlow;
 using Xunit;
 
@@ -14,6 +15,19 @@ namespace TensorFlowSharp.Tests.CSharp
 				var devices = session.ListDevices ();
 
 				Assert.True(devices.Any());
+			}
+		}
+		
+		[Theory]
+		[InlineData("Placeholder")]
+		[InlineData("Placeholder:0")]
+		public void ParseOutput_ThrowsForMissingOp (string name)
+		{
+			using (var graph = new TFGraph ())
+			using (var session = new TFSession (graph))
+			{
+				var runner = session.GetRunner();
+				Assert.Throws<ArgumentOutOfRangeException>(() => runner.AddInput(name, new TFTensor(1)));
 			}
 		}
 	}


### PR DESCRIPTION
Prevent Runner.AddTarget from throwing NullReferenceException

If an operation does not exist in the TfGraph, Runner.AddInput can cause a NullReferenceException. 
Check if the operation exists before attempting to get the outputs and throw ArgumentOutOfRangeException if it does not exist.