### PR TITLE
Set shared_name of variable to non-null name

### DIFF
--- a/TensorFlowSharp/OperationsExtras.cs
+++ b/TensorFlowSharp/OperationsExtras.cs
@@ -119,7 +119,7 @@ namespace TensorFlow
 
 			using (var newScope = WithScope (scopeName)) {
 				var type = initialValue.OutputType;
-				var variableHandle = VarHandleOp (type, new TFShape (GetShape (initialValue)), shared_name: operName);
+				var variableHandle = VarHandleOp (type, new TFShape (GetShape (initialValue)), shared_name: scopeName);
 				using (var aScope = WithScope ("Assign")) {
 					var assignOp = AssignVariableOp (variableHandle, initialValue);
 					using (var rScope = WithScope ("Read")) {

--- a/tests/TensorFlowSharp.Tests.CSharp/VariableTests.cs
+++ b/tests/TensorFlowSharp.Tests.CSharp/VariableTests.cs
@@ -10,6 +10,22 @@ namespace TensorFlowSharp.Tests.CSharp
     public class VariableTests
     {
         [Fact]
+        public void ShouldNotShareVariablesSameTypeNoName()
+        {
+            using (var graph = new TFGraph())
+            {
+                var v1 = graph.Variable(graph.Const(0.5f));
+                var v2 = graph.Variable(graph.Const(0.6f));
+
+                using (var session = new TFSession(graph))
+                {
+                    session.GetRunner().AddTarget(graph.GetGlobalVariablesInitializer()).Run();
+                    var result = session.GetRunner().Fetch(v1.Read, v2.Read).Run();
+                    Assert.NotEqual(result[0].GetValue(), result[1].GetValue());
+                }
+            }
+        }
+        [Fact]
         public void ShouldNotShareVariablesSameType()
         {
             using (var graph = new TFGraph())
@@ -19,12 +35,29 @@ namespace TensorFlowSharp.Tests.CSharp
 
                 using (var session = new TFSession(graph))
                 {
-                    var result = session.GetRunner().AddTarget(graph.GetGlobalVariablesInitializer()).Fetch(v1.Read, v2.Read).Run();
+                    session.GetRunner().AddTarget(graph.GetGlobalVariablesInitializer()).Run();
+                    var result = session.GetRunner().Fetch(v1.Read, v2.Read).Run();
                     Assert.NotEqual(result[0].GetValue(), result[1].GetValue());
                 }
             }
         }
 
+        [Fact]
+        public void ShouldNotShareVariablesDifferentTypeNoName()
+        {
+            using (var graph = new TFGraph())
+            {
+                var v1 = graph.Variable(graph.Const(0.5f));
+                var v2 = graph.Variable(graph.Const(0L));
+
+                using (var session = new TFSession(graph))
+                {
+                    session.GetRunner().AddTarget(graph.GetGlobalVariablesInitializer()).Run();
+                    var result = session.GetRunner().Fetch(v1.Read, v2.Read).Run();
+                    Assert.NotEqual(result[0].TensorType, result[1].TensorType);
+                }
+            }
+        }
         [Fact]
         public void ShouldNotShareVariablesDifferentType()
         {
@@ -35,7 +68,8 @@ namespace TensorFlowSharp.Tests.CSharp
 
                 using (var session = new TFSession(graph))
                 {
-                    var result = session.GetRunner().AddTarget(graph.GetGlobalVariablesInitializer()).Fetch(v1.Read, v2.Read).Run();
+                    session.GetRunner().AddTarget(graph.GetGlobalVariablesInitializer()).Run();
+                    var result = session.GetRunner().Fetch(v1.Read, v2.Read).Run();
                     Assert.NotEqual(result[0].TensorType, result[1].TensorType);
                 }
             }


### PR DESCRIPTION
Shared name was being set to the optional parameter `operName` which causes issues when no variable name is given.  This switches it to `scopeName` which is just "VariableXX" in the missing case.