### PR TITLE
Pack libtensorflow.dll at runtimes/win-x64/native

### DIFF
--- a/TensorFlowSharp/TensorFlowSharp.csproj
+++ b/TensorFlowSharp/TensorFlowSharp.csproj
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
     <PackageId>TensorFlowSharp</PackageId>
-    <PackageVersion>1.15.2</PackageVersion>
+    <PackageVersion>1.15.3</PackageVersion>
     <Authors>Miguel de Icaza</Authors>
     <PackageLicenseUrl>https://github.com/migueldeicaza/TensorFlowSharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/migueldeicaza/TensorFlowSharp/</PackageProjectUrl>
@@ -23,7 +23,7 @@
     <Description>.NET Bindings for TensorFlow</Description>
     <Owners>Miguel de Icaza</Owners>
     <Summary>.NET API for TensorFlow, Google's Machine Intelligence framework</Summary>
-    <PackageReleaseNotes>1.15.1: Add a Runner.Run method that does not allocate - contribution from Enrico Minack; 1.15.0: Updated to TensorFlow 1.15; 1.13.1: Fixes boolean and ushort tensor construction fixes from Enrico Minack;  Runner.AddInput fixes from Colin Versteeg; captainst provided a convenience function for the samples; Zeeshan Ahmed added AdamOptimizer; Kevin Malenfant fixes a few bugs; Enrico Minack added support for mutable tensors;  1.13.0: An optimization implementation now exists for C#, contributed by Zeeshan Ahmed from the Microsoft data science team (RMSProp, SGD optimizer bindings);  TFSession now has a static method for loading models;  New methods for loading strings into tensors (also Zeeshan)</PackageReleaseNotes>
+    <PackageReleaseNotes>1.15.3: Fixed libtensorflow.dll not being copied to output directory on .NET Core; 1.15.1: Add a Runner.Run method that does not allocate - contribution from Enrico Minack; 1.15.0: Updated to TensorFlow 1.15; 1.13.1: Fixes boolean and ushort tensor construction fixes from Enrico Minack;  Runner.AddInput fixes from Colin Versteeg; captainst provided a convenience function for the samples; Zeeshan Ahmed added AdamOptimizer; Kevin Malenfant fixes a few bugs; Enrico Minack added support for mutable tensors;  1.13.0: An optimization implementation now exists for C#, contributed by Zeeshan Ahmed from the Microsoft data science team (RMSProp, SGD optimizer bindings);  TFSession now has a static method for loading models;  New methods for loading strings into tensors (also Zeeshan)</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TensorFlowSharp/TensorFlowSharp.csproj
+++ b/TensorFlowSharp/TensorFlowSharp.csproj
@@ -30,6 +30,7 @@
     <None Remove="nuget\build\net45\TensorFlowSharp.targets" />
     <None Include="nuget\build\net45\TensorFlowSharp.targets" PackagePath="build\net45\TensorFlowSharp.targets" Pack="true" />
     <None Include="..\native\libtensorflow.dll" Link="nuget\runtimes\win7-x64\native\libtensorflow.dll" PackagePath="runtimes\win7-x64\native\libtensorflow.dll" Pack="true" />
+    <None Include="..\native\libtensorflow.dll" Link="nuget\runtimes\win-x64\native\libtensorflow.dll" PackagePath="runtimes\win-x64\native\libtensorflow.dll" Pack="true" />
     <None Include="..\native\libtensorflow.dylib" Link="nuget\runtimes\osx\native\libtensorflow.dylib" PackagePath="runtimes\osx\native\libtensorflow.dylib" Pack="true" />
     <None Include="..\native\libtensorflow_framework.dylib" Link="nuget\runtimes\osx\native\libtensorflow_framework.dylib" PackagePath="runtimes\osx\native\libtensorflow_framework.dylib" Pack="true" />
     <None Include="..\native\libtensorflow.so" Link="nuget\runtimes\linux\native\libtensorflow.so" PackagePath="runtimes\linux\native\libtensorflow.so" Pack="true" />


### PR DESCRIPTION
In .NET Core projects that consume TensorFlowSharp with RuntimeIdentifier=win-x64, `libtensorflow.dll` is never copied to the output directory. This change also packs `libtensorflow.dll` at win-x64 too. I didn't get rid of win7-x64 for the sake of backwards compatibility.